### PR TITLE
Removed "_id" from userModel.js

### DIFF
--- a/Models/userModel.js
+++ b/Models/userModel.js
@@ -1,7 +1,6 @@
 const mongoose = require("mongoose");
 
 module.exports = new mongoose.Schema({
-    _id: Number,
     firstName: {
         type: String,
         required: true


### PR DESCRIPTION
In order to prevent conflict that might be caused by using "mongoose-auto-increment", "_id" has been removed from userModel.js.
Each schema that will extend "userModel.js" schema should create its own instance of the plugin.